### PR TITLE
🐛  #bugfix Flush rendered dependent template nodes

### DIFF
--- a/dist/snuggsi.es
+++ b/dist/snuggsi.es
@@ -167,49 +167,32 @@ const HTMLTemplateElement = Template = function (name) {
 
     let
       clone
-    , tokens
-    , fragments = []
-    , dependent = undefined
     , template = document.createElement ('template')
 
-    this.dependents =
-      this.dependents || []
+    void (this.dependents || [])
+      .map (dependent => dependent.remove ())
 
-    while
-      (dependent = this.dependents.pop ())
-        dependent.remove ()
-
+    this.dependents = []
 
     template.innerHTML =
-    contexts.map ((c, index) => {
-      console.log (c, index)
-
-      contexts [index] =
-        typeof contexts [index]  === 'object'
-          ? contexts [index]
-          : { self: contexts [index] }
-
-      contexts [index]
-        ['#'] = index
+    contexts.map ((context, index) => {
+      context = (typeof context  === 'object') ? context : { self: context }
+      context ['#'] = index
 
       clone  = this.cloneNode (true)
-      tokens = (new TokenList (clone.content))
 
-      tokens.bind (contexts [index])
-      return clone
+      void (new TokenList (clone.content))
+        .bind (context)
+
+      return clone.innerHTML
     })
-
-    .map
-      (function (fragment) { this.dependents.push (...fragment.content.childNodes); return fragment }, this)
-
-    .map (record => record.innerHTML)
     .join ('')
 
+    this.dependents.push (...template.content.childNodes)
     this.after ( template.content )
 
     return this
   }
-
 }
 
 const EventTarget = Element => // why buble

--- a/dist/snuggsi.es
+++ b/dist/snuggsi.es
@@ -183,25 +183,18 @@ const HTMLTemplateElement = Template = function (name) {
 
       clone  = this.cloneNode (true)
       tokens = (new TokenList (clone.content))
+
+      contexts [index] =
+        typeof contexts [index]  === 'object'
+          ? contexts [index]
+          : { self: contexts [index] }
+
+      contexts [index]
+        ['#'] = index
+
+      tokens.bind (contexts [index])
+      fragments.push (clone)
     })
-
-//  while (index--) {
-
-//    let
-//      clone  = this.cloneNode (true)
-//    , tokens = (new TokenList (clone.content))
-
-//    contexts [index] =
-//      typeof contexts [index]  === 'object'
-//        ? contexts [index]
-//        : { self: contexts [index] }
-
-//    contexts [index]
-//      ['#'] = index
-
-//    tokens.bind (contexts [index])
-//    fragments.push (clone)
-//  }
 
     fragments.map
       (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)

--- a/dist/snuggsi.es
+++ b/dist/snuggsi.es
@@ -163,15 +163,8 @@ const HTMLTemplateElement = Template = function (name) {
     (document.querySelector ('template[name='+name+']'), { bind } )
 
   function bind (context) {
-
-    console.log ('what')
-
-    this.dependents =
-      this.dependents || []
-
-    context =
-      (Array.isArray (context) ? context : [context])
-      .reverse ()
+    contexts = [].concat (...[context])
+    console.log ('contexts', contexts)
 
     let
       dependent = undefined
@@ -179,11 +172,18 @@ const HTMLTemplateElement = Template = function (name) {
     const
       fragments = []
 
+    this.dependents =
+      this.dependents || []
+
     while
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
     let index = context.length
+
+    contexts.map ((c, index) => {
+      console.log (c, index)
+    })
 
     while (index--) {
 
@@ -191,20 +191,20 @@ const HTMLTemplateElement = Template = function (name) {
         clone  = this.cloneNode (true)
       , tokens = (new TokenList (clone.content))
 
-      context [index]  =
-        typeof context [index]  === 'object'
-          ? context [index]
-          : { self: context [index] }
+      contexts [index] =
+        typeof contexts [index]  === 'object'
+          ? contexts [index]
+          : { self: contexts [index] }
 
-      context [index]
+      contexts [index]
         ['#'] = index
 
-      tokens.bind  (context [index])
+      tokens.bind (contexts [index])
       fragments.push (clone)
     }
 
     fragments.map
-      (function (record) { this.dependents.push (...record.content.childNodes) }, this)
+      (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)
 
     let template = document.createElement ('template')
 
@@ -213,10 +213,14 @@ const HTMLTemplateElement = Template = function (name) {
       .join ('')
 
     template.innerHTML = a
+
+    console.log (template.content.childNodes)
+
     this.after ( template.content )
 
     return this
   }
+
 }
 
 const EventTarget = Element => // why buble

--- a/dist/snuggsi.es
+++ b/dist/snuggsi.es
@@ -170,6 +170,7 @@ const HTMLTemplateElement = Template = function (name) {
     , tokens
     , fragments = []
     , dependent = undefined
+    , template = document.createElement ('template')
 
     this.dependents =
       this.dependents || []
@@ -178,11 +179,10 @@ const HTMLTemplateElement = Template = function (name) {
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
+
+    template.innerHTML =
     contexts.map ((c, index) => {
       console.log (c, index)
-
-      clone  = this.cloneNode (true)
-      tokens = (new TokenList (clone.content))
 
       contexts [index] =
         typeof contexts [index]  === 'object'
@@ -192,22 +192,18 @@ const HTMLTemplateElement = Template = function (name) {
       contexts [index]
         ['#'] = index
 
+      clone  = this.cloneNode (true)
+      tokens = (new TokenList (clone.content))
+
       tokens.bind (contexts [index])
-      fragments.push (clone)
+      return clone
     })
 
-    fragments.map
-      (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)
+    .map
+      (function (fragment) { this.dependents.push (...fragment.content.childNodes); return fragment }, this)
 
-    let template = document.createElement ('template')
-
-    let a = fragments
-      .map (record => record.innerHTML)
-      .join ('')
-
-    template.innerHTML = a
-
-    console.log (template.content.childNodes)
+    .map (record => record.innerHTML)
+    .join ('')
 
     this.after ( template.content )
 

--- a/dist/snuggsi.es
+++ b/dist/snuggsi.es
@@ -163,14 +163,13 @@ const HTMLTemplateElement = Template = function (name) {
     (document.querySelector ('template[name='+name+']'), { bind } )
 
   function bind (context) {
-    contexts = [].concat (...[context])
-    console.log ('contexts', contexts)
+    contexts = [].concat ( ... [context] )
 
     let
-      dependent = undefined
-
-    const
-      fragments = []
+      clone
+    , tokens
+    , fragments = []
+    , dependent = undefined
 
     this.dependents =
       this.dependents || []
@@ -179,29 +178,30 @@ const HTMLTemplateElement = Template = function (name) {
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
-    let index = context.length
-
     contexts.map ((c, index) => {
       console.log (c, index)
+
+      clone  = this.cloneNode (true)
+      tokens = (new TokenList (clone.content))
     })
 
-    while (index--) {
+//  while (index--) {
 
-      let
-        clone  = this.cloneNode (true)
-      , tokens = (new TokenList (clone.content))
+//    let
+//      clone  = this.cloneNode (true)
+//    , tokens = (new TokenList (clone.content))
 
-      contexts [index] =
-        typeof contexts [index]  === 'object'
-          ? contexts [index]
-          : { self: contexts [index] }
+//    contexts [index] =
+//      typeof contexts [index]  === 'object'
+//        ? contexts [index]
+//        : { self: contexts [index] }
 
-      contexts [index]
-        ['#'] = index
+//    contexts [index]
+//      ['#'] = index
 
-      tokens.bind (contexts [index])
-      fragments.push (clone)
-    }
+//    tokens.bind (contexts [index])
+//    fragments.push (clone)
+//  }
 
     fragments.map
       (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)

--- a/dist/snuggsi.es
+++ b/dist/snuggsi.es
@@ -164,6 +164,8 @@ const HTMLTemplateElement = Template = function (name) {
 
   function bind (context) {
 
+    console.log ('what')
+
     this.dependents =
       this.dependents || []
 
@@ -175,7 +177,7 @@ const HTMLTemplateElement = Template = function (name) {
       dependent = undefined
 
     const
-      records = []
+      fragments = []
 
     while
       (dependent = this.dependents.pop ())
@@ -198,15 +200,15 @@ const HTMLTemplateElement = Template = function (name) {
         ['#'] = index
 
       tokens.bind  (context [index])
-      records.push (clone)
+      fragments.push (clone)
     }
 
-    records.map
+    fragments.map
       (function (record) { this.dependents.push (...record.content.childNodes) }, this)
 
     let template = document.createElement ('template')
 
-    let a = records
+    let a = fragments
       .map (record => record.innerHTML)
       .join ('')
 

--- a/dist/snuggsi.es
+++ b/dist/snuggsi.es
@@ -451,8 +451,6 @@ const Component = Element => // why buble
       .from // templates with `name` attribute
         (this.selectAll ('template[name]'))
 
-      .map (template => !!! console.log (template) && template)
-
       .map
         (template => template.getAttribute ('name'))
 

--- a/elements/component.es
+++ b/elements/component.es
@@ -25,8 +25,6 @@ const Component = Element => // why buble
       .from // templates with `name` attribute
         (this.selectAll ('template[name]'))
 
-      .map (template => !!! console.log (template) && template)
-
       .map
         (template => template.getAttribute ('name'))
 

--- a/elements/html-template-element.es
+++ b/elements/html-template-element.es
@@ -13,6 +13,7 @@ const HTMLTemplateElement = Template = function (name) {
     , tokens
     , fragments = []
     , dependent = undefined
+    , template = document.createElement ('template')
 
     this.dependents =
       this.dependents || []
@@ -21,11 +22,10 @@ const HTMLTemplateElement = Template = function (name) {
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
+
+    template.innerHTML =
     contexts.map ((c, index) => {
       console.log (c, index)
-
-      clone  = this.cloneNode (true)
-      tokens = (new TokenList (clone.content))
 
       contexts [index] =
         typeof contexts [index]  === 'object'
@@ -35,22 +35,18 @@ const HTMLTemplateElement = Template = function (name) {
       contexts [index]
         ['#'] = index
 
+      clone  = this.cloneNode (true)
+      tokens = (new TokenList (clone.content))
+
       tokens.bind (contexts [index])
-      fragments.push (clone)
+      return clone
     })
 
-    fragments.map
-      (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)
+    .map
+      (function (fragment) { this.dependents.push (...fragment.content.childNodes); return fragment }, this)
 
-    let template = document.createElement ('template')
-
-    let a = fragments
-      .map (record => record.innerHTML)
-      .join ('')
-
-    template.innerHTML = a
-
-    console.log (template.content.childNodes)
+    .map (record => record.innerHTML)
+    .join ('')
 
     this.after ( template.content )
 

--- a/elements/html-template-element.es
+++ b/elements/html-template-element.es
@@ -10,48 +10,31 @@ const HTMLTemplateElement = Template = function (name) {
 
     let
       clone
-    , tokens
-    , fragments = []
-    , dependent = undefined
     , template = document.createElement ('template')
 
-    this.dependents =
-      this.dependents || []
+    void (this.dependents || [])
+      .map (dependent => dependent.remove ())
 
-    while
-      (dependent = this.dependents.pop ())
-        dependent.remove ()
-
+    this.dependents = []
 
     template.innerHTML =
-    contexts.map ((c, index) => {
-      console.log (c, index)
-
-      contexts [index] =
-        typeof contexts [index]  === 'object'
-          ? contexts [index]
-          : { self: contexts [index] }
-
-      contexts [index]
-        ['#'] = index
+    contexts.map ((context, index) => {
+      context = (typeof context  === 'object') ? context : { self: context }
+      context ['#'] = index
 
       clone  = this.cloneNode (true)
-      tokens = (new TokenList (clone.content))
 
-      tokens.bind (contexts [index])
-      return clone
+      void (new TokenList (clone.content))
+        .bind (context)
+
+      return clone.innerHTML
     })
-
-    .map
-      (function (fragment) { this.dependents.push (...fragment.content.childNodes); return fragment }, this)
-
-    .map (record => record.innerHTML)
     .join ('')
 
+    this.dependents.push (...template.content.childNodes)
     this.after ( template.content )
 
     return this
   }
-
 }
 

--- a/elements/html-template-element.es
+++ b/elements/html-template-element.es
@@ -26,25 +26,18 @@ const HTMLTemplateElement = Template = function (name) {
 
       clone  = this.cloneNode (true)
       tokens = (new TokenList (clone.content))
+
+      contexts [index] =
+        typeof contexts [index]  === 'object'
+          ? contexts [index]
+          : { self: contexts [index] }
+
+      contexts [index]
+        ['#'] = index
+
+      tokens.bind (contexts [index])
+      fragments.push (clone)
     })
-
-//  while (index--) {
-
-//    let
-//      clone  = this.cloneNode (true)
-//    , tokens = (new TokenList (clone.content))
-
-//    contexts [index] =
-//      typeof contexts [index]  === 'object'
-//        ? contexts [index]
-//        : { self: contexts [index] }
-
-//    contexts [index]
-//      ['#'] = index
-
-//    tokens.bind (contexts [index])
-//    fragments.push (clone)
-//  }
 
     fragments.map
       (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)

--- a/elements/html-template-element.es
+++ b/elements/html-template-element.es
@@ -7,6 +7,8 @@ const HTMLTemplateElement = Template = function (name) {
 
   function bind (context) {
 
+    console.log ('what')
+
     this.dependents =
       this.dependents || []
 
@@ -18,7 +20,7 @@ const HTMLTemplateElement = Template = function (name) {
       dependent = undefined
 
     const
-      records = []
+      fragments = []
 
     while
       (dependent = this.dependents.pop ())
@@ -41,15 +43,15 @@ const HTMLTemplateElement = Template = function (name) {
         ['#'] = index
 
       tokens.bind  (context [index])
-      records.push (clone)
+      fragments.push (clone)
     }
 
-    records.map
+    fragments.map
       (function (record) { this.dependents.push (...record.content.childNodes) }, this)
 
     let template = document.createElement ('template')
 
-    let a = records
+    let a = fragments
       .map (record => record.innerHTML)
       .join ('')
 

--- a/elements/html-template-element.es
+++ b/elements/html-template-element.es
@@ -6,14 +6,13 @@ const HTMLTemplateElement = Template = function (name) {
     (document.querySelector ('template[name='+name+']'), { bind } )
 
   function bind (context) {
-    contexts = [].concat (...[context])
-    console.log ('contexts', contexts)
+    contexts = [].concat ( ... [context] )
 
     let
-      dependent = undefined
-
-    const
-      fragments = []
+      clone
+    , tokens
+    , fragments = []
+    , dependent = undefined
 
     this.dependents =
       this.dependents || []
@@ -22,29 +21,30 @@ const HTMLTemplateElement = Template = function (name) {
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
-    let index = context.length
-
     contexts.map ((c, index) => {
       console.log (c, index)
+
+      clone  = this.cloneNode (true)
+      tokens = (new TokenList (clone.content))
     })
 
-    while (index--) {
+//  while (index--) {
 
-      let
-        clone  = this.cloneNode (true)
-      , tokens = (new TokenList (clone.content))
+//    let
+//      clone  = this.cloneNode (true)
+//    , tokens = (new TokenList (clone.content))
 
-      contexts [index] =
-        typeof contexts [index]  === 'object'
-          ? contexts [index]
-          : { self: contexts [index] }
+//    contexts [index] =
+//      typeof contexts [index]  === 'object'
+//        ? contexts [index]
+//        : { self: contexts [index] }
 
-      contexts [index]
-        ['#'] = index
+//    contexts [index]
+//      ['#'] = index
 
-      tokens.bind (contexts [index])
-      fragments.push (clone)
-    }
+//    tokens.bind (contexts [index])
+//    fragments.push (clone)
+//  }
 
     fragments.map
       (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)

--- a/elements/html-template-element.es
+++ b/elements/html-template-element.es
@@ -6,15 +6,8 @@ const HTMLTemplateElement = Template = function (name) {
     (document.querySelector ('template[name='+name+']'), { bind } )
 
   function bind (context) {
-
-    console.log ('what')
-
-    this.dependents =
-      this.dependents || []
-
-    context =
-      (Array.isArray (context) ? context : [context])
-      .reverse ()
+    contexts = [].concat (...[context])
+    console.log ('contexts', contexts)
 
     let
       dependent = undefined
@@ -22,11 +15,18 @@ const HTMLTemplateElement = Template = function (name) {
     const
       fragments = []
 
+    this.dependents =
+      this.dependents || []
+
     while
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
     let index = context.length
+
+    contexts.map ((c, index) => {
+      console.log (c, index)
+    })
 
     while (index--) {
 
@@ -34,20 +34,20 @@ const HTMLTemplateElement = Template = function (name) {
         clone  = this.cloneNode (true)
       , tokens = (new TokenList (clone.content))
 
-      context [index]  =
-        typeof context [index]  === 'object'
-          ? context [index]
-          : { self: context [index] }
+      contexts [index] =
+        typeof contexts [index]  === 'object'
+          ? contexts [index]
+          : { self: contexts [index] }
 
-      context [index]
+      contexts [index]
         ['#'] = index
 
-      tokens.bind  (context [index])
+      tokens.bind (contexts [index])
       fragments.push (clone)
     }
 
     fragments.map
-      (function (record) { this.dependents.push (...record.content.childNodes) }, this)
+      (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)
 
     let template = document.createElement ('template')
 
@@ -56,9 +56,13 @@ const HTMLTemplateElement = Template = function (name) {
       .join ('')
 
     template.innerHTML = a
+
+    console.log (template.content.childNodes)
+
     this.after ( template.content )
 
     return this
   }
+
 }
 

--- a/examples/infinity-calendar/infinity-calendar.es
+++ b/examples/infinity-calendar/infinity-calendar.es
@@ -6,7 +6,6 @@ Element `infinity-calendar`
     { this.context.date = new Date }
 
   static onidle () {
-    console.log ('idling')
 
     this.select
       ('[name=month]').value = this.month

--- a/examples/infinity-calendar/infinity-calendar.es
+++ b/examples/infinity-calendar/infinity-calendar.es
@@ -87,9 +87,7 @@ Element `infinity-calendar`
     for (let day=1; day <= date.getDate (); day++)
       dates.push (day)
 
-    return [1,2,3,4]
-
-//  return dates.map (days)
+    return dates.map (days)
   }
 
   date_from_month (change) {

--- a/examples/infinity-calendar/infinity-calendar.es
+++ b/examples/infinity-calendar/infinity-calendar.es
@@ -6,6 +6,8 @@ Element `infinity-calendar`
     { this.context.date = new Date }
 
   static onidle () {
+    console.log ('idling')
+
     this.select
       ('[name=month]').value = this.month
 

--- a/snuggsi.js
+++ b/snuggsi.js
@@ -167,49 +167,32 @@ const HTMLTemplateElement = Template = function (name) {
 
     let
       clone
-    , tokens
-    , fragments = []
-    , dependent = undefined
     , template = document.createElement ('template')
 
-    this.dependents =
-      this.dependents || []
+    void (this.dependents || [])
+      .map (dependent => dependent.remove ())
 
-    while
-      (dependent = this.dependents.pop ())
-        dependent.remove ()
-
+    this.dependents = []
 
     template.innerHTML =
-    contexts.map ((c, index) => {
-      console.log (c, index)
-
-      contexts [index] =
-        typeof contexts [index]  === 'object'
-          ? contexts [index]
-          : { self: contexts [index] }
-
-      contexts [index]
-        ['#'] = index
+    contexts.map ((context, index) => {
+      context = (typeof context  === 'object') ? context : { self: context }
+      context ['#'] = index
 
       clone  = this.cloneNode (true)
-      tokens = (new TokenList (clone.content))
 
-      tokens.bind (contexts [index])
-      return clone
+      void (new TokenList (clone.content))
+        .bind (context)
+
+      return clone.innerHTML
     })
-
-    .map
-      (function (fragment) { this.dependents.push (...fragment.content.childNodes); return fragment }, this)
-
-    .map (record => record.innerHTML)
     .join ('')
 
+    this.dependents.push (...template.content.childNodes)
     this.after ( template.content )
 
     return this
   }
-
 }
 
 const EventTarget = Element => // why buble

--- a/snuggsi.js
+++ b/snuggsi.js
@@ -183,25 +183,18 @@ const HTMLTemplateElement = Template = function (name) {
 
       clone  = this.cloneNode (true)
       tokens = (new TokenList (clone.content))
+
+      contexts [index] =
+        typeof contexts [index]  === 'object'
+          ? contexts [index]
+          : { self: contexts [index] }
+
+      contexts [index]
+        ['#'] = index
+
+      tokens.bind (contexts [index])
+      fragments.push (clone)
     })
-
-//  while (index--) {
-
-//    let
-//      clone  = this.cloneNode (true)
-//    , tokens = (new TokenList (clone.content))
-
-//    contexts [index] =
-//      typeof contexts [index]  === 'object'
-//        ? contexts [index]
-//        : { self: contexts [index] }
-
-//    contexts [index]
-//      ['#'] = index
-
-//    tokens.bind (contexts [index])
-//    fragments.push (clone)
-//  }
 
     fragments.map
       (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)

--- a/snuggsi.js
+++ b/snuggsi.js
@@ -163,15 +163,8 @@ const HTMLTemplateElement = Template = function (name) {
     (document.querySelector ('template[name='+name+']'), { bind } )
 
   function bind (context) {
-
-    console.log ('what')
-
-    this.dependents =
-      this.dependents || []
-
-    context =
-      (Array.isArray (context) ? context : [context])
-      .reverse ()
+    contexts = [].concat (...[context])
+    console.log ('contexts', contexts)
 
     let
       dependent = undefined
@@ -179,11 +172,18 @@ const HTMLTemplateElement = Template = function (name) {
     const
       fragments = []
 
+    this.dependents =
+      this.dependents || []
+
     while
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
     let index = context.length
+
+    contexts.map ((c, index) => {
+      console.log (c, index)
+    })
 
     while (index--) {
 
@@ -191,20 +191,20 @@ const HTMLTemplateElement = Template = function (name) {
         clone  = this.cloneNode (true)
       , tokens = (new TokenList (clone.content))
 
-      context [index]  =
-        typeof context [index]  === 'object'
-          ? context [index]
-          : { self: context [index] }
+      contexts [index] =
+        typeof contexts [index]  === 'object'
+          ? contexts [index]
+          : { self: contexts [index] }
 
-      context [index]
+      contexts [index]
         ['#'] = index
 
-      tokens.bind  (context [index])
+      tokens.bind (contexts [index])
       fragments.push (clone)
     }
 
     fragments.map
-      (function (record) { this.dependents.push (...record.content.childNodes) }, this)
+      (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)
 
     let template = document.createElement ('template')
 
@@ -213,10 +213,14 @@ const HTMLTemplateElement = Template = function (name) {
       .join ('')
 
     template.innerHTML = a
+
+    console.log (template.content.childNodes)
+
     this.after ( template.content )
 
     return this
   }
+
 }
 
 const EventTarget = Element => // why buble

--- a/snuggsi.js
+++ b/snuggsi.js
@@ -170,6 +170,7 @@ const HTMLTemplateElement = Template = function (name) {
     , tokens
     , fragments = []
     , dependent = undefined
+    , template = document.createElement ('template')
 
     this.dependents =
       this.dependents || []
@@ -178,11 +179,10 @@ const HTMLTemplateElement = Template = function (name) {
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
+
+    template.innerHTML =
     contexts.map ((c, index) => {
       console.log (c, index)
-
-      clone  = this.cloneNode (true)
-      tokens = (new TokenList (clone.content))
 
       contexts [index] =
         typeof contexts [index]  === 'object'
@@ -192,22 +192,18 @@ const HTMLTemplateElement = Template = function (name) {
       contexts [index]
         ['#'] = index
 
+      clone  = this.cloneNode (true)
+      tokens = (new TokenList (clone.content))
+
       tokens.bind (contexts [index])
-      fragments.push (clone)
+      return clone
     })
 
-    fragments.map
-      (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)
+    .map
+      (function (fragment) { this.dependents.push (...fragment.content.childNodes); return fragment }, this)
 
-    let template = document.createElement ('template')
-
-    let a = fragments
-      .map (record => record.innerHTML)
-      .join ('')
-
-    template.innerHTML = a
-
-    console.log (template.content.childNodes)
+    .map (record => record.innerHTML)
+    .join ('')
 
     this.after ( template.content )
 

--- a/snuggsi.js
+++ b/snuggsi.js
@@ -163,14 +163,13 @@ const HTMLTemplateElement = Template = function (name) {
     (document.querySelector ('template[name='+name+']'), { bind } )
 
   function bind (context) {
-    contexts = [].concat (...[context])
-    console.log ('contexts', contexts)
+    contexts = [].concat ( ... [context] )
 
     let
-      dependent = undefined
-
-    const
-      fragments = []
+      clone
+    , tokens
+    , fragments = []
+    , dependent = undefined
 
     this.dependents =
       this.dependents || []
@@ -179,29 +178,30 @@ const HTMLTemplateElement = Template = function (name) {
       (dependent = this.dependents.pop ())
         dependent.remove ()
 
-    let index = context.length
-
     contexts.map ((c, index) => {
       console.log (c, index)
+
+      clone  = this.cloneNode (true)
+      tokens = (new TokenList (clone.content))
     })
 
-    while (index--) {
+//  while (index--) {
 
-      let
-        clone  = this.cloneNode (true)
-      , tokens = (new TokenList (clone.content))
+//    let
+//      clone  = this.cloneNode (true)
+//    , tokens = (new TokenList (clone.content))
 
-      contexts [index] =
-        typeof contexts [index]  === 'object'
-          ? contexts [index]
-          : { self: contexts [index] }
+//    contexts [index] =
+//      typeof contexts [index]  === 'object'
+//        ? contexts [index]
+//        : { self: contexts [index] }
 
-      contexts [index]
-        ['#'] = index
+//    contexts [index]
+//      ['#'] = index
 
-      tokens.bind (contexts [index])
-      fragments.push (clone)
-    }
+//    tokens.bind (contexts [index])
+//    fragments.push (clone)
+//  }
 
     fragments.map
       (function (fragment) { this.dependents.push (...fragment.content.childNodes) }, this)

--- a/snuggsi.js
+++ b/snuggsi.js
@@ -164,6 +164,8 @@ const HTMLTemplateElement = Template = function (name) {
 
   function bind (context) {
 
+    console.log ('what')
+
     this.dependents =
       this.dependents || []
 
@@ -175,7 +177,7 @@ const HTMLTemplateElement = Template = function (name) {
       dependent = undefined
 
     const
-      records = []
+      fragments = []
 
     while
       (dependent = this.dependents.pop ())
@@ -198,15 +200,15 @@ const HTMLTemplateElement = Template = function (name) {
         ['#'] = index
 
       tokens.bind  (context [index])
-      records.push (clone)
+      fragments.push (clone)
     }
 
-    records.map
+    fragments.map
       (function (record) { this.dependents.push (...record.content.childNodes) }, this)
 
     let template = document.createElement ('template')
 
-    let a = records
+    let a = fragments
       .map (record => record.innerHTML)
       .join ('')
 

--- a/snuggsi.js
+++ b/snuggsi.js
@@ -451,8 +451,6 @@ const Component = Element => // why buble
       .from // templates with `name` attribute
         (this.selectAll ('template[name]'))
 
-      .map (template => !!! console.log (template) && template)
-
       .map
         (template => template.getAttribute ('name'))
 


### PR DESCRIPTION
Fixes #41

There is a bug that after every template render the previous nodes are not flushed. Therefore appending instead of being idempotent and replacing. https://en.wikipedia.org/wiki/Idempotence