### PR TITLE
Remove static keyword from the event handler

### DIFF
--- a/elements/component.es
+++ b/elements/component.es
@@ -31,9 +31,6 @@ const Component = Element => // why buble
 
   render () {
 
-    this.tokens
-      .bind (this)
-
     Array
       .from // templates with `name` attribute
         (this.selectAll ('template[name]'))
@@ -43,6 +40,9 @@ const Component = Element => // why buble
 
       .map
         (name => (new Template (name)).bind (this [name]))
+
+    this.tokens
+      .bind (this)
 
     this.reflect ()
 

--- a/elements/component.es
+++ b/elements/component.es
@@ -31,6 +31,8 @@ const Component = Element => // why buble
 
   render () {
 
+    this.tokens.bind (this)
+
     Array
       .from // templates with `name` attribute
         (this.selectAll ('template[name]'))
@@ -41,15 +43,16 @@ const Component = Element => // why buble
       .map
         (name => (new Template (name)).bind (this [name]))
 
-    this.tokens
-      .bind (this)
+    Array
+      .from (this.selectAll ('*'))
 
-    this.reflect ()
+      .concat ([this])
+
+      .map (this.reflect, this)
 
     // dispatch `idle`
     // and captured from `EventTarget`
-    super.onidle &&
-      super.onidle () // TODO: Migrate to `EventTarget`
+    super.onidle && super.onidle ()
   }
 
   // This doesn't go here. Perhaps SlotList / Template / TokenList (in that order)
@@ -91,5 +94,6 @@ const Component = Element => // why buble
 
     this.innerHTML = template.innerHTML
   }
+
 })
 

--- a/elements/component.es
+++ b/elements/component.es
@@ -91,6 +91,5 @@ const Component = Element => // why buble
 
     this.innerHTML = template.innerHTML
   }
-
 })
 

--- a/elements/component.es
+++ b/elements/component.es
@@ -53,7 +53,7 @@ const Component = Element => // why buble
   }
 
   // This doesn't go here. Perhaps SlotList / Template / TokenList (in that order)
-  clone (template) {
+  parse (template) {
 
     const
       fragment = template.content

--- a/elements/component.es
+++ b/elements/component.es
@@ -10,12 +10,16 @@ const Component = Element => // why buble
 
     this.context = {}
 
+    this.tokens = new TokenList (this)
+
+    Object
+      .getOwnPropertyNames (Element.prototype)
+      .map (this.introspect, this)
+
     // dispatch `initialize`
     // and captured from `EventTarget`
     this.initialize
       && this.initialize ()
-
-    this.tokens = new TokenList (this)
   }
 
   connectedCallback () {

--- a/elements/component.es
+++ b/elements/component.es
@@ -48,8 +48,8 @@ const Component = Element => // why buble
 
     // dispatch `idle`
     // and captured from `EventTarget`
-    Element.onidle &&
-      Element.onidle.call (this) // TODO: Migrate to `EventTarget`
+    super.onidle &&
+      super.onidle () // TODO: Migrate to `EventTarget`
   }
 
   // This doesn't go here. Perhaps SlotList / Template / TokenList (in that order)

--- a/elements/event-target.es
+++ b/elements/event-target.es
@@ -22,18 +22,32 @@ const EventTarget = Element => // why buble
 
 (class extends Element {
 
-  on ( event, handler )
+  // MDN EventTarget.addEventListener
+  // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+  //
+  // WHATWG Living Standard EventTarget.addEventListener
+  // https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener
+  //
+  // DOM Level 2 EventTarget.addEventListener
+  // https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget-addEventListener
 
-    // MDN EventTarget.addEventListener
-    // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
-    //
-    // WHATWG Living Standard EventTarget.addEventListener
-    // https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener
-    //
-    // DOM Level 2 EventTarget.addEventListener
-    // https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget-addEventListener
 
-    { this.addEventListener ( event, handler ) }
+  on ( event, handler ) {
+
+    this.addEventListener
+      (event, this.renderable (handler))
+  }
+
+  renderable ( handler ) {
+
+    return (event, render = true) =>
+      (event.prevent = _ =>
+         (render = false) && event.preventDefault ())
+
+      && handler.call (this, event) !== false // for `return false`
+
+      && render && this.render () // check render availability
+  }
 
 //off (event, listener = 'on' + this [event])
 //  // MDN EventTarget.removeEventListener

--- a/elements/global-event-handlers.es
+++ b/elements/global-event-handlers.es
@@ -34,7 +34,7 @@ const GlobalEventHandlers = Element =>
       && this.parse (document.querySelector ('template'))
 
     super.onconnect
-      && super.onconnect.call (this)
+      && super.onconnect ()
 
     this.render ()
   }

--- a/elements/global-event-handlers.es
+++ b/elements/global-event-handlers.es
@@ -31,7 +31,7 @@ const GlobalEventHandlers = Element =>
   onconnect (event, document) {
 
     (document = event.target.import)
-      && this.clone (document.querySelector ('template'))
+      && this.parse (document.querySelector ('template'))
 
     super.onconnect
       && super.onconnect.call (this)

--- a/elements/global-event-handlers.es
+++ b/elements/global-event-handlers.es
@@ -50,24 +50,14 @@ const GlobalEventHandlers = Element =>
   // which goes a step further and is the ability for a program to manipulate the values,
   // meta-data, properties and/or functions of an object at runtime.
 
-  introspect () {
+  introspect (handler, name) {
+    ( name = ( handler.match (/^on(.+)$/) || [] ) [1] )
 
-    const
-      introspect = handler =>
-        /^on/.test (handler)
-        && (this [handler] === null) // ensure W3C on event
-        && (this [handler] = render (Element [handler]))
+    && Object.keys // ensure W3C on event
+     ( HTMLElement.prototype )
+       .includes ( handler )
 
-    , render = handle =>
-        (event, render = true) =>
-        !!! console.log ('woohoo') &&
-          (event.prevent = _ => (render = null) && event.preventDefault ())
-            && handle.call (this, event) !== false // for `return false`
-            && render && this.render () // check render availability
-
-    Object
-      .getOwnPropertyNames (Element)
-      .map (introspect)
+    && this.on (name, this [handler])
   }
 
   reflect () {

--- a/elements/global-event-handlers.es
+++ b/elements/global-event-handlers.es
@@ -60,33 +60,19 @@ const GlobalEventHandlers = Element =>
     && this.on (name, this [handler])
   }
 
-  reflect () {
-
+  reflect (node) {
     const
-      reflect = node =>
-        Array
-          .from (node.attributes)
-          .map (attr => attr.name)
-          .filter (name => /^on/.test (name))
-          .map (register (node))
+      register = (event, handler) =>
+        (handler = /{\s*(\w+)\s*}/.exec (node [event]))
 
-    , register = node =>
-        (event, handler) =>
-          (handler = /{\s*(\w+)\s*}/.exec (node [event]))
-            && ( handler = (handler || []) [1] )
-            && ( handler = Element [handler] ) // change to `this [handler]` for `static` removal
-            && ( node [event] = render (handler) )
-
-    , render = handle =>
-        (event, render = true) =>
-          (event.prevent = _ => (render = null) && event.preventDefault ())
-            && handle.call (this, event) !== false // for `return false`
-            && render && this.render () // check render availability
+        && ( handler = this [ (handler || []) [1] ] )
+        && ( node [event] = this.renderable (handler) )
 
     Array
-      .from (this.querySelectorAll ('*'))
-      .concat ([this])
-      .map (reflect)
+      .from (node.attributes)
+      .map (attr => attr.name)
+      .filter (name => /^on/.test (name))
+      .map (register)
   }
 })
 

--- a/elements/global-event-handlers.es
+++ b/elements/global-event-handlers.es
@@ -60,6 +60,7 @@ const GlobalEventHandlers = Element =>
 
     , render = handle =>
         (event, render = true) =>
+        !!! console.log ('woohoo') &&
           (event.prevent = _ => (render = null) && event.preventDefault ())
             && handle.call (this, event) !== false // for `return false`
             && render && this.render () // check render availability
@@ -84,7 +85,14 @@ const GlobalEventHandlers = Element =>
           (handler = /{\s*(\w+)\s*}/.exec (node [event]))
             && ( handler = (handler || []) [1] )
             && ( handler = Element [handler] ) // change to `this [handler]` for `static` removal
-            && ( node [event] = handler.bind (this) )
+            && ( node [event] = render (handler) )
+
+    , render = handle =>
+        (event, render = true) =>
+          console.log ('woohoo') &&
+          (event.prevent = _ => (render = null) && event.preventDefault ())
+            && handle.call (this, event) !== false // for `return false`
+            && render && this.render () // check render availability
 
     Array
       .from (this.querySelectorAll ('*'))

--- a/elements/global-event-handlers.es
+++ b/elements/global-event-handlers.es
@@ -79,7 +79,6 @@ const GlobalEventHandlers = Element =>
 
     , render = handle =>
         (event, render = true) =>
-          console.log ('woohoo') &&
           (event.prevent = _ => (render = null) && event.preventDefault ())
             && handle.call (this, event) !== false // for `return false`
             && render && this.render () // check render availability

--- a/examples/add-subtract.html
+++ b/examples/add-subtract.html
@@ -76,12 +76,12 @@ Element `add-subtract`
   initialize ()
     { this.context.count = 0 }
 
-  static increment () {
+  increment () {
     this.context.count ++
     this.render ()
   }
 
-  static decrement () {
+  decrement () {
     this.context.count --
     this.render ()
   }

--- a/examples/file-upload/script.es
+++ b/examples/file-upload/script.es
@@ -113,7 +113,7 @@ Element `file-upload`
     return mimetypes
   }
 
-  static onconnect () {
+  onconnect () {
     console.log (this.mimetypes)
   }
 
@@ -124,7 +124,7 @@ Element `file-upload`
    * @param event {Event} The event that has been triggered.
    */
 
-  static onchange (event) {
+  onchange (event) {
     console.log ('change')
 
     if (!!! event.target.files) return
@@ -154,7 +154,7 @@ Element `file-upload`
    * @param event {MouseEvent} The event that has been triggered. 
    */
 
-  static onremove (event) {
+  onremove (event) {
 
     // http://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript
     this.context.files = []
@@ -162,7 +162,7 @@ Element `file-upload`
     this.render ()
   }
 
-  static onclear (event) {
+  onclear (event) {
 
     // http://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript
     this.context.files = []
@@ -177,7 +177,7 @@ Element `file-upload`
    * @param event {DragEvent} The event that has been triggered.
    */
 
-  static ondragleave (event) {
+  ondragleave (event) {
 
     this.select ('label')
       .textContent = this.label
@@ -190,7 +190,7 @@ Element `file-upload`
    * @param event {DragEvent} The event that has been triggered. 
    */
 
-  static ondragenter (event) {
+  ondragenter (event) {
 
     this.select ('label')
       .textContent = this.title
@@ -203,7 +203,7 @@ Element `file-upload`
    * @param event {DragEvent} The event that has been triggered.
    */
 
-  static ondrop (event) {
+  ondrop (event) {
   console.log ('drop')
 
     const

--- a/examples/infinity-calendar/infinity-calendar.es
+++ b/examples/infinity-calendar/infinity-calendar.es
@@ -14,7 +14,6 @@ Element `infinity-calendar`
   }
 
   onchange () {
-    console.log ('what', this)
     const
       month =
         this.select

--- a/examples/infinity-calendar/infinity-calendar.es
+++ b/examples/infinity-calendar/infinity-calendar.es
@@ -5,18 +5,16 @@ Element `infinity-calendar`
   initialize ()
     { this.context.date = new Date }
 
-  static onidle () {
-
+  onidle () {
     this.select
       `[name=month]`.value = this.month
 
     this.select
       `[name=year]`.value = this.year
-
   }
 
-  static onchange () {
-
+  onchange () {
+    console.log ('what', this)
     const
       month =
         this.select
@@ -30,13 +28,13 @@ Element `infinity-calendar`
       new Date (year, month, 1)
   }
 
-  static onnext ()
+  onnext ()
     { this.date_from_month (+1) }
 
-  static onprevious ()
+  onprevious ()
     { this.date_from_month (-1) }
 
-  static ondayclick (event)
+  ondayclick (event)
     { alert (event.target.textContent) }
 
   get year ()
@@ -46,7 +44,6 @@ Element `infinity-calendar`
     { return this.context.date.getMonth () }
 
   get years () {
-
     const
       deviation = 5
     , years = new Array
@@ -59,14 +56,12 @@ Element `infinity-calendar`
   }
 
   get months () {
-
     return [
       'January', 'February', 'March', 'April', 'May',
       'June', 'July','August','September','October','November','December' ]
   }
 
   get days () {
-
     const
       dates = []
     , daily = undefined
@@ -87,6 +82,5 @@ Element `infinity-calendar`
     this.context.date = new Date
       (this.context.date.setMonth (this.month + change))
   }
-
 })
 

--- a/examples/input-output.html
+++ b/examples/input-output.html
@@ -37,7 +37,7 @@ Element `input-output`
 
 (class extends HTMLElement {
 
-  static oninput () { }
+  oninput () { }
 
   get echo () // tokenized property
     { return this.select ('input#message').value || '…' }

--- a/examples/options-scanner.html
+++ b/examples/options-scanner.html
@@ -74,7 +74,7 @@ Element `options-settings`
 
 (class extends HTMLElement {
 
-  static onsubmit (event) {
+  onsubmit (event) {
     event.preventDefault ()
 
     console.log ('now you can shit')

--- a/examples/x-flashy.html
+++ b/examples/x-flashy.html
@@ -55,7 +55,8 @@ Element `x-flashy`
 
   static get speed () { return 3000 }
 
-  static onclick (event) { console.log ('mole whacked') }
+  onclick (event)
+    { console.log ('mole whacked') }
 
   initialize () {
 


### PR DESCRIPTION
Fixes #45 as per @janz93's request.

This is a breaking change @janz93 @RobertChristopher @brandondees @mrbernnz @albertoponti 

```javascript
(class extends HTMLElement {
  
  static onclick () // "automagic" event registration
    { alert (this.textContent) }
})
```
 to be only
```javascript
(class extends HTMLElement {
  
  onclick () // "automagic" event registration
    { alert (this.textContent) }
})
```
