### PR TITLE
💅 refactor <infinity-calendar>

### DIFF
--- a/examples/infinity-calendar/index.html
+++ b/examples/infinity-calendar/index.html
@@ -51,12 +51,12 @@
   </header>
 
   <menu>
-    <button onclick=onprevious>Previous</button>
-    <button onclick=onnext>Next</button>
+    <button onclick=previous>Previous</button>
+    <button onclick=next>Next</button>
   </menu>
 
   <template name=days>
-    <a href=#{day} onclick=ondayclick>
+    <a href=#{day} onclick=dayclick>
       <time datetime>{day}</time>
     </a>
   </template>

--- a/examples/infinity-calendar/infinity-calendar.es
+++ b/examples/infinity-calendar/infinity-calendar.es
@@ -62,19 +62,14 @@ Element `infinity-calendar`
 
   get days () {
     const
-      dates = []
-    , daily = undefined
+      next_month = this.month + 1
+    , date = new Date (this.year , next_month, 0)
+    , length = { length: date.getDate () }
+    , days = (_, index) => ({ day: index +1 })
 
-    , days  = day =>
-        { return { day: day } }
-
-    , date  =
-        new Date ( this.year , this.context.date.getMonth () + 1 , 0)
-
-    for (let day=1; day <= date.getDate (); day++)
-      dates.push (day)
-
-    return dates.map (days)
+    return Array
+      .apply (null, length)
+      .map (days)
   }
 
   date_from_month (change) {

--- a/examples/infinity-calendar/infinity-calendar.es
+++ b/examples/infinity-calendar/infinity-calendar.es
@@ -27,13 +27,13 @@ Element `infinity-calendar`
       new Date (year, month, 1)
   }
 
-  onnext ()
+  next ()
     { this.date_from_month (+1) }
 
-  onprevious ()
+  previous ()
     { this.date_from_month (-1) }
 
-  ondayclick (event)
+  dayclick (event)
     { alert (event.target.textContent) }
 
   get year ()


### PR DESCRIPTION
 @brandondees @RobertChristopher @mrbernnz @robcole @janz93 @btakita @albertoponti  After pairing with @lukemelia & @samphippen last night at GORUCO mind was rattling on some refactors for our [`<infinity-calendar>` example](http://snuggsi.herokuapp.com/examples/infinity-calendar).

I don't quite recall the FULL intent. @lukemelia perhaps can shed some light on the dangers of prefixing exotic event handlers with `on`. This opens the door for the rare chance the platform specs implement (`onluke`, `onfoo` etc.) within _[`GlobalEventHandlers`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers)_

## Prerequisite
[Declarative vs. Imperative Programming](https://tylermcginnis.com/imperative-vs-declarative-programming)

## Declarative Event Registration
```html
<button onclick=foo>Click Me</button>

<!-- this (NAMING) convention is now deprecated in snuggsi -->
<!-- <button onclick=onfoo>Deprecated</button> -->
```
## Imperative Event Registration
```javascript
(class extends HTMLElement {

  foo () {} // better naming convention (sans `on`)

  // this (NAMING) convention is now deprecated in snuggsi
  // onfoo () {}
})
```

However I believe there is one convention we can implement for _(nearly)_ "free". If an event handler is _declaratively_ bound to the `HTMLElement` (i.e. `onclick=onfoo`) through `GlobalEventHandler.register ()`
Then we should bypass this handler on `Element.introspect ()`ion.

## Declarative Event Naming Conventions
```html
<foo-bar> Declarative Event Registration
  <button id=baz onclick=onclick>Click Me</button>
</foo-bar>

<script>

Element `foo-bar`

(class extends HTMLElement {

  onclick (event) {

    // due to the fact there was a declarative event registration `onclick=onclick`
    // snuggsi will bypass imperative (automagic) event registration
    // of this event handler from being delegated
    // to `foo-bar` custom element parent element.

    console.log `${event.target} is button#baz`
  }
}) 

</script>
```
## Imperative Event Naming Conventions

```html
<!-- <foo-bar onclick=onclick> -->
<foo-bar> Imperative Event Registration
  <button>Click Me</button>
</foo-bar>

<script>

Element `foo-bar`

(class extends HTMLElement {

  onclick (event) {

    // this.introspect ()
    // is called which will auto-register
    // methods from this class which align
    // with the GlobalEventHandlers.on* events.
    // see: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
    // This event handler delegates
    // to `foo-bar` custom element parent element.

    // Equivalent to
    // this.on ('click', this.onclick)
    // Using the snuggsi method `GlobalEventHandlers.on (event, handler)`

    console.log `${event.target} is foo-bar`
  }
}) 

</script>
```

The best part about the code review was the only changes we had to change were our thinking. Not core. 

What I DO love @RobertChristopher is our goal of < 100LOC calendar is now at about [~80LOC in `.es`](https://github.com/devpunks/snuggsi/blob/1abe3bdf9083b7fdd209632061b5729adc9cbd1f/examples/infinity-calendar/infinity-calendar.es)
and [~30LOC in `.html`](https://github.com/devpunks/snuggsi/blob/1abe3bdf9083b7fdd209632061b5729adc9cbd1f/examples/infinity-calendar/index.html#L37-L64)
for a fairly well working calendar.

No code, like no code. /cc @tmornini 