### PR TITLE
Fixes #64 set document <title> within <nav-view>

### DIFF
--- a/examples/nav-view/example.html
+++ b/examples/nav-view/example.html
@@ -38,3 +38,5 @@
   <p>You've come a long way baby!</p>
 </main>
 
+<script src=/browser-sync.es></script>
+

--- a/examples/nav-view/index.es
+++ b/examples/nav-view/index.es
@@ -26,8 +26,6 @@ Element `nav-view`
   onview (event, anchor = event.target) {
     event.prevent ()
 
-    history.pushState ({}, anchor.title, anchor.href)
-
     this.context.views.map (this.hide)
 
     this.identify (event.target)

--- a/examples/nav-view/index.es
+++ b/examples/nav-view/index.es
@@ -32,6 +32,8 @@ Element `nav-view`
 
     this.identify (event.target)
       .hidden = false
+
+    document.title = anchor.title
   }
 
   hide (view)


### PR DESCRIPTION
@RobertChristopher Fixes #64 

@brandondees this is one of the two main features of [TurboLinks](https://github.com/turbolinks/turbolinks).
The other being hot swaping content like we do with imports. However Turbolinks "hot swap"s the `document.body`. Hence why events have to be placed on `document.body`. But I digress.

/cc @albertoponti @robcole @mrbernnz @janz93 

## Result



![issue-64](https://user-images.githubusercontent.com/38223/27544268-9b0046c6-5a5a-11e7-91ac-50224d18590b.gif)
