### PR TITLE
🐛  #bugfix Issue #135 multiple custom elements only render the first element

### DIFF
--- a/elements/component.es
+++ b/elements/component.es
@@ -54,7 +54,8 @@ const Custom = Element => // why buble
 
     this
       .templates
-      .map (template => template.bind (this [template.name]))
+      .map (template =>
+        template.bind (this [template.name]))
 
     this
       .tokens

--- a/elements/html-template-element.es
+++ b/elements/html-template-element.es
@@ -8,8 +8,13 @@
 const Template = HTMLTemplateElement = function (template) {
 
   template =
-    (typeof template == 'string')
+    typeof template == 'string'
       ? document.querySelector ('template[name='+template+']')
+      : template
+
+  template =
+    this === HTMLTemplateElement
+      ? template.cloneNode (true)
       : template
 
   template.name =

--- a/examples/ie.html
+++ b/examples/ie.html
@@ -23,6 +23,21 @@
   </template>
 </hello-world>
 
+<hello-world>
+  Hello World Again!!! {baz}
+
+  <template name=snuggs>
+    <section style=background:pink;color:green;>
+      <h1>{self}</h1>
+
+      WOW ! {#}
+      <footer>
+        <button onclick=onrob>Score</button>
+      </footer>
+    </section>
+  </template>
+</hello-world>
+
 <!--
   <hello-world>Hello Sun!!!</hello-world>
   <hello-world>Hello Moon!!!</hello-world>


### PR DESCRIPTION
🐛 bugfix #135 @albertoponti 

## Reproduction
![image](https://user-images.githubusercontent.com/13278394/29746050-7099c58a-8a9b-11e7-9f78-ee84930308fe.png)



## Prerequisite Understanding
- [MDN `document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
- [MDN `document.querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll)
- [MDN `<template>` Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)



## Problem
The logic we used here is based off `document.querySelector` to find all templates within the custom element. (Or so we thought). `document.querySelector` only finds the FIRST template it finds from the selector. Which will always be the first element.

## Code in Question
1. [`this.render ()` Templating logic](https://github.com/devpunks/snuggsi/blob/master/elements/component.es#L50-L58)
2. [`HTMLTemplateElement` initialization routine](https://github.com/devpunks/snuggsi/blob/master/elements/html-template-element.es#L5-L8)

# Solution
 We now are sending the template directly from within the scope of the custom element. Before we were just sending template name into `new Template`. However `new Template('somename')` is merely a standalone way of using `Template`. It will just go looking in the `document` for a template of the name you pass in. *Alternatively* _(and this is a big alternative)_ `new Template (node)` can also take a Node as a parameter.

In our `this.render` routine we did the following operation:

_problematic operations highlighted_

1. Find all templates with a name property within custom element.
2. ~~map a collection of `name`s for each template.~~
3. **call `new Template (name)` for each template.**
  a. **use `document.querySelector` to grab `<template name=...>`**
4. **`.bind (data)` to `<template>`**

*We can actually totally remove 2* and we ensure the templates retrieved are scoped to the custom element.

### Questions

1. What do we do in the situation of multiple templates of the same `name` within a single custom element? _(@brandondees @robcole @angelocordon)_

```html
<foo-bar>
  <template name=baz>...</template>
  <template name=baz>...</template>
</foo-bar>
```
2. What standalone API do we want to support (this is huge @albertoponti @brandondees @robcole @tmornini because #developerErgonomics )

```js
new Template('name') // I think should be a classic default
let node = document.querySelector ('template')
new Template (node) // creating from existing template node

Template `name` // modern approach but can't send a node in via tagged templates.
```
@robcole we actually have this issue in Funderbolt but circumvent by explicit binding the `(new Template (...)).bind (data)` which is similar to how snuggsi internals work (which means we're doing too much).

@tmornini dude perfect example of removing code and removing a bug too. Actually gaining functionality by removing code. Check the diff. ;-)
