### PR TITLE
Security: Use of document.write in browser-sync.js

### DIFF
--- a/browser-sync.js
+++ b/browser-sync.js
@@ -1,12 +1,14 @@
 void function () {
 
-  let script = '<script src=\/browser-sync\/browser-sync-client.js><\/script>'
-
   void (
     (location.hostname.indexOf ('localhost')    >= 0)
       || (location.hostname.indexOf ('192.168') >= 0)
       || (location.hostname.indexOf ('127.0')   >= 0)
   )
 
-  && document.write (script)
+  && function () {
+    let script = document.createElement ('script')
+    script.src = '/browser-sync/browser-sync-client.js'
+    document.head.appendChild (script)
+  } ()
 } ()


### PR DESCRIPTION
## Summary

Security: Use of document.write in browser-sync.js

## Problem

**Severity**: `Medium` | **File**: `browser-sync.js:L10`

The browser-sync.js file uses document.write() to inject a script tag. document.write is dangerous as it can overwrite the entire document if called after the document has finished loading, and it is a known vector for XSS attacks. Additionally, the script source is hardcoded to a local browser-sync endpoint.

## Solution

Replace document.write with safer DOM manipulation methods like document.createElement('script') and document.head.appendChild(). Consider removing this file from production builds entirely as browser-sync is a development tool.

## Changes

- `browser-sync.js` (modified)